### PR TITLE
test: creating subscription with no dependencies

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: start local registry and begin e2e-local tests
         run: |
           "${GITHUB_WORKSPACE}/scripts/start_registry.sh"
-          "make e2e-local NODES=2 JUNIT_DIRECTORY=./artifacts/ TOOLS_BIN=\"${GITHUB_WORKSPACE}/${TOOLS_BIN_RELATIVE_PATH}\""
+          make e2e-local NODES=2 JUNIT_DIRECTORY=./artifacts/ TOOLS_BIN="${GITHUB_WORKSPACE}/${TOOLS_BIN_RELATIVE_PATH}"
 
       - name: Archive Test Artifacts # test results, failed or not, are always uploaded.
         if: ${{ always() }}

--- a/test/e2e/catalogutil/catalog.go
+++ b/test/e2e/catalogutil/catalog.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/operator-framework/api/pkg/lib/version"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 
 	"github.com/operator-framework/operator-registry/pkg/lib/bundle"
@@ -1350,7 +1351,7 @@ func createCSVTemplate(catalogEntry *CatalogEntry) (*operatorsv1alpha1.ClusterSe
 			},
 			DisplayName: catalogEntry.PackageName,
 			InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
-				StrategyName: "install",
+				StrategyName: v1alpha1.InstallStrategyNameDeployment,
 				StrategySpec: operatorsv1alpha1.StrategyDetailsDeployment{
 					DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
 						{

--- a/test/e2e/crd_e2e_test.go
+++ b/test/e2e/crd_e2e_test.go
@@ -520,7 +520,7 @@ var _ = Describe("CRD Versions", func() {
 	})
 })
 
-func fetchCRD(c operatorclient.ClientInterface, crc versioned.Interface, name, namespace string) (*v1beta1.CustomResourceDefinition, error) {
+func fetchCRD(c operatorclient.ClientInterface, crc versioned.Interface, name string) (*v1beta1.CustomResourceDefinition, error) {
 	// TODO: add a fuction for v1.CRD
 	var fetchedCRD *v1beta1.CustomResourceDefinition
 	var err error

--- a/test/e2e/crd_e2e_test.go
+++ b/test/e2e/crd_e2e_test.go
@@ -9,11 +9,14 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 	"github.com/operator-framework/operator-lifecycle-manager/test/e2e/ctx"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -516,3 +519,19 @@ var _ = Describe("CRD Versions", func() {
 		GinkgoT().Log("manually reconciled potentially unsafe CRD upgrade")
 	})
 })
+
+func fetchCRD(c operatorclient.ClientInterface, crc versioned.Interface, name, namespace string) (*v1beta1.CustomResourceDefinition, error) {
+	// TODO: add a fuction for v1.CRD
+	var fetchedCRD *v1beta1.CustomResourceDefinition
+	var err error
+
+	Eventually(func() (bool, error) {
+		fetchedCRD, err = c.ApiextensionsInterface().ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	}).Should(BeTrue())
+	// TODO add logging
+	return fetchedCRD, err
+}

--- a/test/e2e/sample_e2e_test.go
+++ b/test/e2e/sample_e2e_test.go
@@ -114,12 +114,11 @@ var _ = Describe("Sample", func() {
 
 			// TODO: do we need to create catalog images are each scenario ? can we move building images to once per test suite (group of tests that uses the catalog)
 			// don't want to rebuild the image if it already exists
-			operatorImage := "quay.io/cdjohnson/ibm-sample-panamax-operator@sha256:47c9fcef261f3f26dbb6c05f904d11563aae43f61d72e0e4556399f3003c97d0"
-			operatorCommand := []string{"ibm-sample-panamax-operator"}
+			operatorImage := *dummyImage
 			catalogEntry := []cu.CatalogEntry{
-				{Version: semver.MustParse("1.0.0"), ReplacesVersion: "", SkipRange: "", DefaultChannel: "alpha", Channels: []string{"alpha"}, NewIndex: true, PackageName: "testoperatora", OwnedGVKs: cu.A1v1CRDDescription, DependencyGVKs: nil, DependencyPackages: nil, Addmode: cu.SemverSkipPatch, ConfigMap: nil, Secret: nil, CrdVersions: cu.V1CRDVersionV1beta1, OperatorImage: operatorImage, OperatorCommand: operatorCommand},
-				{Version: semver.MustParse("1.0.1"), ReplacesVersion: "", SkipRange: "<1.0.1", DefaultChannel: "alpha", Channels: []string{"alpha"}, NewIndex: false, PackageName: "testoperatora", OwnedGVKs: cu.A1v1CRDDescription, DependencyGVKs: nil, DependencyPackages: nil, Addmode: cu.SemverSkipPatch, ConfigMap: nil, Secret: nil, CrdVersions: cu.V1CRDVersionV1beta1, OperatorImage: operatorImage, OperatorCommand: operatorCommand},
-				{Version: semver.MustParse("1.0.0"), ReplacesVersion: "", SkipRange: "", DefaultChannel: "alpha", Channels: []string{"alpha"}, NewIndex: false, PackageName: "testoperatorb", OwnedGVKs: cu.B1v1CRDDescription, DependencyGVKs: cu.A1v1CRDDescription, DependencyPackages: nil, Addmode: cu.SemverSkipPatch, ConfigMap: nil, Secret: nil, CrdVersions: cu.V1CRDVersionV1beta1, OperatorImage: operatorImage, OperatorCommand: operatorCommand},
+				{Version: semver.MustParse("1.0.0"), ReplacesVersion: "", SkipRange: "", DefaultChannel: "alpha", Channels: []string{"alpha"}, NewIndex: true, PackageName: "testoperatora", OwnedGVKs: cu.A1v1CRDDescription, DependencyGVKs: nil, DependencyPackages: nil, Addmode: cu.SemverSkipPatch, ConfigMap: nil, Secret: nil, CrdVersions: cu.V1CRDVersionV1beta1, OperatorImage: operatorImage, OperatorCommand: nil},
+				{Version: semver.MustParse("1.0.1"), ReplacesVersion: "", SkipRange: "<1.0.1", DefaultChannel: "alpha", Channels: []string{"alpha"}, NewIndex: false, PackageName: "testoperatora", OwnedGVKs: cu.A1v1CRDDescription, DependencyGVKs: nil, DependencyPackages: nil, Addmode: cu.SemverSkipPatch, ConfigMap: nil, Secret: nil, CrdVersions: cu.V1CRDVersionV1beta1, OperatorImage: operatorImage, OperatorCommand: nil},
+				{Version: semver.MustParse("1.0.0"), ReplacesVersion: "", SkipRange: "", DefaultChannel: "alpha", Channels: []string{"alpha"}, NewIndex: false, PackageName: "testoperatorb", OwnedGVKs: cu.B1v1CRDDescription, DependencyGVKs: cu.A1v1CRDDescription, DependencyPackages: nil, Addmode: cu.SemverSkipPatch, ConfigMap: nil, Secret: nil, CrdVersions: cu.V1CRDVersionV1beta1, OperatorImage: operatorImage, OperatorCommand: nil},
 			}
 			stack := cu.Stack{
 				OpmBinarySourceImage: cu.Upstream1_15,
@@ -148,7 +147,7 @@ var _ = Describe("Sample", func() {
 			defer cleanupSource()
 
 			// ensure the catalog exists and has been synced by the catalog operator
-			_, err = fetchCatalogSourceOnStatus(crc, catalogSourceName, operatorNamespace, catalogSourceRegistryPodSynced)
+			_, err = fetchCatalogSourceOnStatus(crc, catalogSourceName, testNamespace, catalogSourceRegistryPodSynced)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// action
@@ -166,7 +165,7 @@ var _ = Describe("Sample", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// 2. crd
-			wantCRDName := cu.A1v1CRDDescription[0].PluralName
+			wantCRDName := cu.A1v1CRDDescription[0].Description.Name
 			_, err = fetchCRD(c, crc, wantCRDName, testNamespace)
 			Expect(err).ShouldNot(HaveOccurred())
 		})

--- a/test/e2e/sample_e2e_test.go
+++ b/test/e2e/sample_e2e_test.go
@@ -1,12 +1,33 @@
 package e2e
 
 import (
+	"fmt"
+
 	"github.com/blang/semver/v4"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/operatorclient"
 	cu "github.com/operator-framework/operator-lifecycle-manager/test/e2e/catalogutil"
 )
 
 var _ = Describe("Sample", func() {
+
+	var (
+		c   operatorclient.ClientInterface
+		crc versioned.Interface
+	)
+	BeforeEach(func() {
+		c = newKubeClient()
+		crc = newCRClient()
+	})
+
+	AfterEach(func() {
+		TearDown(testNamespace)
+	})
+
 	It("SimpleTest", func() {
 
 		operatorImage := "quay.io/cdjohnson/ibm-sample-panamax-operator@sha256:47c9fcef261f3f26dbb6c05f904d11563aae43f61d72e0e4556399f3003c97d0"
@@ -81,4 +102,83 @@ var _ = Describe("Sample", func() {
 		err := cu.CreateTemporaryCatalog(*toolsBin, catalogEntry, stack)
 		_ = err
 	})
+
+	// TODO: determine the correct location for these tests
+	Describe("test with catalog index image created in replaces mode", func() {
+
+		It("create subscription with no dependency", func() {
+
+			// prereqs
+
+			// 1. create catalog image
+
+			// TODO: do we need to create catalog images are each scenario ? can we move building images to once per test suite (group of tests that uses the catalog)
+			// don't want to rebuild the image if it already exists
+			operatorImage := "quay.io/cdjohnson/ibm-sample-panamax-operator@sha256:47c9fcef261f3f26dbb6c05f904d11563aae43f61d72e0e4556399f3003c97d0"
+			operatorCommand := []string{"ibm-sample-panamax-operator"}
+			catalogEntry := []cu.CatalogEntry{
+				{Version: semver.MustParse("1.0.0"), ReplacesVersion: "", SkipRange: "", DefaultChannel: "alpha", Channels: []string{"alpha"}, NewIndex: true, PackageName: "testoperatora", OwnedGVKs: cu.A1v1CRDDescription, DependencyGVKs: nil, DependencyPackages: nil, Addmode: cu.SemverSkipPatch, ConfigMap: nil, Secret: nil, CrdVersions: cu.V1CRDVersionV1beta1, OperatorImage: operatorImage, OperatorCommand: operatorCommand},
+				{Version: semver.MustParse("1.0.1"), ReplacesVersion: "", SkipRange: "<1.0.1", DefaultChannel: "alpha", Channels: []string{"alpha"}, NewIndex: false, PackageName: "testoperatora", OwnedGVKs: cu.A1v1CRDDescription, DependencyGVKs: nil, DependencyPackages: nil, Addmode: cu.SemverSkipPatch, ConfigMap: nil, Secret: nil, CrdVersions: cu.V1CRDVersionV1beta1, OperatorImage: operatorImage, OperatorCommand: operatorCommand},
+				{Version: semver.MustParse("1.0.0"), ReplacesVersion: "", SkipRange: "", DefaultChannel: "alpha", Channels: []string{"alpha"}, NewIndex: false, PackageName: "testoperatorb", OwnedGVKs: cu.B1v1CRDDescription, DependencyGVKs: cu.A1v1CRDDescription, DependencyPackages: nil, Addmode: cu.SemverSkipPatch, ConfigMap: nil, Secret: nil, CrdVersions: cu.V1CRDVersionV1beta1, OperatorImage: operatorImage, OperatorCommand: operatorCommand},
+			}
+			stack := cu.Stack{
+				OpmBinarySourceImage: cu.Upstream1_15,
+				CatalogFromImage:     cu.Ubi8,
+				CatalogName:          "panamax3",
+				CatalogTag:           "latest",
+				Oc:                   cu.Ocv4_5_0,
+				// Opmdown:              cu.Opmdownv1_14_3,
+				Opmup:             cu.Opmupv1_15_2,
+				OpmDebug:          true,
+				TargetRegistry:    "localhost:5000",
+				ContainerCLI:      cu.Docker,
+				TargetCatalogType: cu.Image,
+			}
+
+			err := cu.CreateTemporaryCatalog(*toolsBin, catalogEntry, stack)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// 2. create namespace
+			// this is already created by testsuite
+
+			// 3. create catalog source
+			catalogSourceName := genName("cat-a")
+			catalogImage := fmt.Sprintf("%s/%s:%s", stack.TargetRegistry, stack.CatalogName, stack.CatalogTag)
+			_, cleanupSource := createGrpcCatalogSource(crc, catalogSourceName, testNamespace, catalogImage)
+			defer cleanupSource()
+
+			// ensure the catalog exists and has been synced by the catalog operator
+			_, err = fetchCatalogSourceOnStatus(crc, catalogSourceName, operatorNamespace, catalogSourceRegistryPodSynced)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// action
+
+			// create subscription
+			subscriptionName := genName("sub-")
+			cleanupSubscription := createSubscriptionForCatalog(crc, testNamespace, subscriptionName, catalogSourceName, "testoperatora", alphaChannel, "", v1alpha1.ApprovalAutomatic)
+			defer cleanupSubscription()
+
+			// expected
+
+			// 1. csv
+			wantCSVName := "testoperatora.v1.0.1"
+			_, err = fetchCSV(crc, wantCSVName, testNamespace, csvSucceededChecker)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// 2. crd
+			wantCRDName := cu.A1v1CRDDescription[0].PluralName
+			_, err = fetchCRD(c, crc, wantCRDName, testNamespace)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+
 })
+
+// TODO: represent test setup as a table entry
+// TestEntry represents a structure to describe a test case
+type TestEntry struct {
+	name     string        // name of the test
+	prereq   []interface{} // prepreq objects that needs to created
+	input    []interface{} // input object that drives the test
+	expected []interface{} // expected objects
+}

--- a/test/e2e/sample_e2e_test.go
+++ b/test/e2e/sample_e2e_test.go
@@ -33,9 +33,9 @@ var _ = Describe("Sample", func() {
 		operatorImage := "quay.io/cdjohnson/ibm-sample-panamax-operator@sha256:47c9fcef261f3f26dbb6c05f904d11563aae43f61d72e0e4556399f3003c97d0"
 		operatorCommand := []string{"ibm-sample-panamax-operator"}
 		catalogEntry := []cu.CatalogEntry{
-			{Version: semver.MustParse("1.0.0"), ReplacesVersion: "", SkipRange: "", DefaultChannel: "alpha", Channels: []string{"alpha"}, NewIndex: true, PackageName: "testoperatora", OwnedGVKs: cu.A1v1CRDDescription, DependencyGVKs: nil, DependencyPackages: nil, Addmode: cu.SemverSkipPatch, ConfigMap: nil, Secret: nil, CrdVersions: cu.V1CRDVersionV1beta1, OperatorImage: operatorImage, OperatorCommand: operatorCommand},
-			{Version: semver.MustParse("1.0.1"), ReplacesVersion: "", SkipRange: "<1.0.1", DefaultChannel: "alpha", Channels: []string{"alpha"}, NewIndex: false, PackageName: "testoperatora", OwnedGVKs: cu.A1v1CRDDescription, DependencyGVKs: nil, DependencyPackages: nil, Addmode: cu.SemverSkipPatch, ConfigMap: nil, Secret: nil, CrdVersions: cu.V1CRDVersionV1beta1, OperatorImage: operatorImage, OperatorCommand: operatorCommand},
-			{Version: semver.MustParse("1.0.0"), ReplacesVersion: "", SkipRange: "", DefaultChannel: "alpha", Channels: []string{"alpha"}, NewIndex: false, PackageName: "testoperatorb", OwnedGVKs: cu.B1v1CRDDescription, DependencyGVKs: cu.A1v1CRDDescription, DependencyPackages: nil, Addmode: cu.SemverSkipPatch, ConfigMap: nil, Secret: nil, CrdVersions: cu.V1CRDVersionV1beta1, OperatorImage: operatorImage, OperatorCommand: operatorCommand},
+			{Version: semver.MustParse("1.0.0"), ReplacesVersion: "", SkipRange: "", DefaultChannel: alphaChannel, Channels: []string{alphaChannel}, NewIndex: true, PackageName: "testoperatora", OwnedGVKs: cu.A1v1CRDDescription, DependencyGVKs: nil, DependencyPackages: nil, Addmode: cu.SemverSkipPatch, ConfigMap: nil, Secret: nil, CrdVersions: cu.V1CRDVersionV1beta1, OperatorImage: operatorImage, OperatorCommand: operatorCommand},
+			{Version: semver.MustParse("1.0.1"), ReplacesVersion: "", SkipRange: "<1.0.1", DefaultChannel: alphaChannel, Channels: []string{alphaChannel}, NewIndex: false, PackageName: "testoperatora", OwnedGVKs: cu.A1v1CRDDescription, DependencyGVKs: nil, DependencyPackages: nil, Addmode: cu.SemverSkipPatch, ConfigMap: nil, Secret: nil, CrdVersions: cu.V1CRDVersionV1beta1, OperatorImage: operatorImage, OperatorCommand: operatorCommand},
+			{Version: semver.MustParse("1.0.0"), ReplacesVersion: "", SkipRange: "", DefaultChannel: alphaChannel, Channels: []string{alphaChannel}, NewIndex: false, PackageName: "testoperatorb", OwnedGVKs: cu.B1v1CRDDescription, DependencyGVKs: cu.A1v1CRDDescription, DependencyPackages: nil, Addmode: cu.SemverSkipPatch, ConfigMap: nil, Secret: nil, CrdVersions: cu.V1CRDVersionV1beta1, OperatorImage: operatorImage, OperatorCommand: operatorCommand},
 		}
 		// TEST FOR DOWNSTREAM REGISTRY
 
@@ -116,9 +116,9 @@ var _ = Describe("Sample", func() {
 			// don't want to rebuild the image if it already exists
 			operatorImage := *dummyImage
 			catalogEntry := []cu.CatalogEntry{
-				{Version: semver.MustParse("1.0.0"), ReplacesVersion: "", SkipRange: "", DefaultChannel: "alpha", Channels: []string{"alpha"}, NewIndex: true, PackageName: "testoperatora", OwnedGVKs: cu.A1v1CRDDescription, DependencyGVKs: nil, DependencyPackages: nil, Addmode: cu.SemverSkipPatch, ConfigMap: nil, Secret: nil, CrdVersions: cu.V1CRDVersionV1beta1, OperatorImage: operatorImage, OperatorCommand: nil},
-				{Version: semver.MustParse("1.0.1"), ReplacesVersion: "", SkipRange: "<1.0.1", DefaultChannel: "alpha", Channels: []string{"alpha"}, NewIndex: false, PackageName: "testoperatora", OwnedGVKs: cu.A1v1CRDDescription, DependencyGVKs: nil, DependencyPackages: nil, Addmode: cu.SemverSkipPatch, ConfigMap: nil, Secret: nil, CrdVersions: cu.V1CRDVersionV1beta1, OperatorImage: operatorImage, OperatorCommand: nil},
-				{Version: semver.MustParse("1.0.0"), ReplacesVersion: "", SkipRange: "", DefaultChannel: "alpha", Channels: []string{"alpha"}, NewIndex: false, PackageName: "testoperatorb", OwnedGVKs: cu.B1v1CRDDescription, DependencyGVKs: cu.A1v1CRDDescription, DependencyPackages: nil, Addmode: cu.SemverSkipPatch, ConfigMap: nil, Secret: nil, CrdVersions: cu.V1CRDVersionV1beta1, OperatorImage: operatorImage, OperatorCommand: nil},
+				{Version: semver.MustParse("1.0.0"), ReplacesVersion: "", SkipRange: "", DefaultChannel: alphaChannel, Channels: []string{alphaChannel}, NewIndex: true, PackageName: "testoperatora", OwnedGVKs: cu.A1v1CRDDescription, DependencyGVKs: nil, DependencyPackages: nil, Addmode: cu.SemverSkipPatch, ConfigMap: nil, Secret: nil, CrdVersions: cu.V1CRDVersionV1beta1, OperatorImage: operatorImage, OperatorCommand: nil},
+				{Version: semver.MustParse("1.0.1"), ReplacesVersion: "", SkipRange: "<1.0.1", DefaultChannel: alphaChannel, Channels: []string{alphaChannel}, NewIndex: false, PackageName: "testoperatora", OwnedGVKs: cu.A1v1CRDDescription, DependencyGVKs: nil, DependencyPackages: nil, Addmode: cu.SemverSkipPatch, ConfigMap: nil, Secret: nil, CrdVersions: cu.V1CRDVersionV1beta1, OperatorImage: operatorImage, OperatorCommand: nil},
+				{Version: semver.MustParse("1.0.0"), ReplacesVersion: "", SkipRange: "", DefaultChannel: alphaChannel, Channels: []string{alphaChannel}, NewIndex: false, PackageName: "testoperatorb", OwnedGVKs: cu.B1v1CRDDescription, DependencyGVKs: cu.A1v1CRDDescription, DependencyPackages: nil, Addmode: cu.SemverSkipPatch, ConfigMap: nil, Secret: nil, CrdVersions: cu.V1CRDVersionV1beta1, OperatorImage: operatorImage, OperatorCommand: nil},
 			}
 			stack := cu.Stack{
 				OpmBinarySourceImage: cu.Upstream1_15,
@@ -166,18 +166,9 @@ var _ = Describe("Sample", func() {
 
 			// 2. crd
 			wantCRDName := cu.A1v1CRDDescription[0].Description.Name
-			_, err = fetchCRD(c, crc, wantCRDName, testNamespace)
+			_, err = fetchCRD(c, crc, wantCRDName)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
 
 })
-
-// TODO: represent test setup as a table entry
-// TestEntry represents a structure to describe a test case
-type TestEntry struct {
-	name     string        // name of the test
-	prereq   []interface{} // prepreq objects that needs to created
-	input    []interface{} // input object that drives the test
-	expected []interface{} // expected objects
-}

--- a/test/e2e/subscription_e2e_test.go
+++ b/test/e2e/subscription_e2e_test.go
@@ -2462,6 +2462,7 @@ func createSubscriptionForCatalog(crc versioned.Interface, namespace, name, cata
 		},
 	}
 
+	ctx.Ctx().Logf("Creating subscription %s in namespace %s...", name, namespace)
 	subscription, err := crc.OperatorsV1alpha1().Subscriptions(namespace).Create(context.Background(), subscription, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred())
 	return buildSubscriptionCleanupFunc(crc, subscription)

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -521,6 +521,37 @@ func buildServiceAccountCleanupFunc(t GinkgoTInterface, c operatorclient.ClientI
 	}
 }
 
+// createGrpcCatalogSource returns catalog source that references catalog index image
+func createGrpcCatalogSource(crc versioned.Interface, name, namespace, imagename string) (*v1alpha1.CatalogSource, cleanupFunc) {
+
+	catalogSource := &v1alpha1.CatalogSource{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       v1alpha1.CatalogSourceKind,
+			APIVersion: v1alpha1.CatalogSourceCRDAPIVersion,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.CatalogSourceSpec{
+			SourceType: "grpc",
+			Image:      imagename,
+		},
+	}
+
+	ctx.Ctx().Logf("Creating catalog source %s in namespace %s...", name, namespace)
+	catalogSource, err := crc.OperatorsV1alpha1().CatalogSources(namespace).Create(context.TODO(), catalogSource, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		Expect(err).ToNot(HaveOccurred())
+	}
+	ctx.Ctx().Logf("Catalog source %s created", name)
+
+	cleanupInternalCatalogSource := func() {
+		buildCatalogSourceCleanupFunc(crc, namespace, catalogSource)()
+	}
+	return catalogSource, cleanupInternalCatalogSource
+}
+
 func createInternalCatalogSource(c operatorclient.ClientInterface, crc versioned.Interface, name, namespace string, manifests []registry.PackageManifest, crds []apiextensions.CustomResourceDefinition, csvs []v1alpha1.ClusterServiceVersion) (*v1alpha1.CatalogSource, cleanupFunc) {
 	configMap, configMapCleanup := createConfigMapForCatalogData(c, name, namespace, manifests, crds, csvs)
 


### PR DESCRIPTION
This test uses a catalog index image built with opm

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.md

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
